### PR TITLE
      fixes for IBM XL compiler 

### DIFF
--- a/wonton/mesh/AuxMeshTopology.h
+++ b/wonton/mesh/AuxMeshTopology.h
@@ -1516,7 +1516,7 @@ void AuxMeshTopology<BasicMesh>::build_face_to_cell_adjacency() {
                                             Entity_type::ALL);
   //  face_cell_ids_.resize(nfaces, {-1, -1});  // I think intel 15 barfs
   //                                            // if I do this
-  std::array<int, 2> iniarr = {-1, -1};
+  std::array<int, 2> iniarr = {{-1, -1}};
   face_cell_ids_.assign(nfaces, iniarr);
   
   int ncells = basicmesh_ptr_->num_entities(Entity_kind::CELL,

--- a/wonton/state/flat/flat_state_mm_wrapper.h
+++ b/wonton/state/flat/flat_state_mm_wrapper.h
@@ -43,8 +43,8 @@ class Flat_State_Wrapper: public StateManager<MeshWrapper> {
     the map from material id to the cells containing that material
   */
   explicit Flat_State_Wrapper(const MeshWrapper& mesh,
-                     std::unordered_map<std::string, int> const& names = {},
-                     std::unordered_map<int, std::vector<int>> const& material_cells = {})
+                              std::unordered_map<std::string, int> const& names = std::unordered_map<std::string, int>{},
+                              std::unordered_map<int, std::vector<int>> const& material_cells = std::unordered_map<int, std::vector<int>>{})
     : StateManager<MeshWrapper>(mesh, names, material_cells) { }
 
 

--- a/wonton/state/simple/simple_state_mm_wrapper.h
+++ b/wonton/state/simple/simple_state_mm_wrapper.h
@@ -30,8 +30,10 @@ class Simple_State_Wrapper: public StateManager<MeshWrapper> {
     @brief Constructor for the state wrapper
    */
   Simple_State_Wrapper(const MeshWrapper& mesh, 
- 			std::unordered_map<std::string,int> names={},
- 			std::unordered_map<int,std::vector<int>> material_cells={}
+		       std::unordered_map<std::string,int> names=
+		       std::unordered_map<std::string,int>{},
+		       std::unordered_map<int,std::vector<int>> material_cells=
+		       std::unordered_map<int,std::vector<int>>{}
  			) :StateManager<MeshWrapper>(mesh,names,material_cells) { }
 
   /// Assignment operator (disabled).

--- a/wonton/state/state_manager.h
+++ b/wonton/state/state_manager.h
@@ -39,8 +39,10 @@ class StateManager {
       material id to the cells containing that material
     */
 StateManager(const MeshWrapper& mesh,
-             std::unordered_map<std::string, int> names = {},
-             std::unordered_map<int, std::vector<int>> material_cells = {})
+             std::unordered_map<std::string, int> names =
+	     std::unordered_map<std::string, int>{},
+             std::unordered_map<int, std::vector<int>> material_cells = 
+	     std::unordered_map<int, std::vector<int>>{})
     :mesh_(mesh) {
     add_material_names(names);
     add_material_cells(material_cells);

--- a/wonton/support/test/test_moment_index.cc
+++ b/wonton/support/test/test_moment_index.cc
@@ -70,19 +70,19 @@ constexpr std::array<int,D> get_exponents();
 
 template<>
 constexpr std::array<int,1> get_exponents<1>() {
-  std::array<int,1> exponents{17};
+  std::array<int,1> exponents{{17}};
   return exponents;
 }
 
 template<>
 constexpr std::array<int,2> get_exponents<2>() {
-  std::array<int,2> exponents{3,2};
+  std::array<int,2> exponents{{3,2}};
   return exponents;
 }
 
 template<>
 constexpr std::array<int,3> get_exponents<3>() {
-  std::array<int,3> exponents{0,2,1};
+  std::array<int,3> exponents{{0,2,1}};
   return exponents;
 }
 

--- a/wonton/support/test/test_structured_partitioner.cc
+++ b/wonton/support/test/test_structured_partitioner.cc
@@ -14,14 +14,14 @@ TEST(StructPartitioner, Serial) {
 
   {
     // Partition 2x2 mesh into 4 partitions (trivial)
-    std::array<int64_t, 2> ncells = {2, 2};
+    std::array<int64_t, 2> ncells = {{2, 2}};
     auto partlimits = Wonton::structured_partitioner<2>(4, ncells);
 
     std::vector<std::vector<std::array<int64_t, 2>>> exp_partlimits = {
-      {{0, 0}, {1, 1}},
-      {{0, 1}, {1, 2}},
-      {{1, 0}, {2, 1}},
-      {{1, 1}, {2, 2}}
+      {{{0, 0}}, {{1, 1}}},
+      {{{0, 1}}, {{1, 2}}},
+      {{{1, 0}}, {{2, 1}}},
+      {{{1, 1}}, {{2, 2}}}
     };
 
     for (int i = 0; i < 4; i++)
@@ -31,15 +31,15 @@ TEST(StructPartitioner, Serial) {
 
   {
     // Partition 2x3 mesh into 4 partitions
-    std::array<int64_t, 2> ncells = {2, 3};
+    std::array<int64_t, 2> ncells = {{2, 3}};
 
     auto partlimits = Wonton::structured_partitioner<2>(4, ncells);
 
     std::vector<std::vector<std::array<int64_t, 2>>> exp_partlimits = {
-      {{0, 0}, {1, 2}},
-      {{0, 2}, {1, 3}},
-      {{1, 0}, {2, 2}},
-      {{1, 2}, {2, 3}}
+      {{{0, 0}}, {{1, 2}}},
+      {{{0, 2}}, {{1, 3}}},
+      {{{1, 0}}, {{2, 2}}},
+      {{{1, 2}}, {{2, 3}}}
     };
 
     for (int i = 0; i < 4; i++)
@@ -49,14 +49,14 @@ TEST(StructPartitioner, Serial) {
 
   {
     // Partition 55x10 mesh into 3 partitions
-    std::array<int64_t, 2> ncells = {55, 10};
+    std::array<int64_t, 2> ncells = {{55, 10}};
 
     auto partlimits = Wonton::structured_partitioner<2>(3, ncells);
 
     std::vector<std::vector<std::array<int64_t, 2>>> exp_partlimits = {
-      {{ 0, 0}, {19, 10}},
-      {{19, 0}, {37, 10}},
-      {{37, 0}, {55, 10}}
+      {{{ 0, 0}}, {{19, 10}}},
+      {{{19, 0}}, {{37, 10}}},
+      {{{37, 0}}, {{55, 10}}}
     };
 
     for (int i = 0; i < 3; i++)
@@ -66,15 +66,15 @@ TEST(StructPartitioner, Serial) {
 
   {
     // Partition 55x10 mesh into 4 partitions BUT ONLY IN 1 DIR
-    std::array<int64_t, 2> ncells = {55, 10};
+    std::array<int64_t, 2> ncells = {{55, 10}};
 
     auto partlimits = Wonton::structured_partitioner<2>(4, ncells, 1);
 
     std::vector<std::vector<std::array<int64_t, 2>>> exp_partlimits = {
-      {{ 0, 0}, {14, 10}},
-      {{14, 0}, {28, 10}},
-      {{28, 0}, {42, 10}},
-      {{42, 0}, {55, 10}}
+      {{{ 0, 0}}, {{14, 10}}},
+      {{{14, 0}}, {{28, 10}}},
+      {{{28, 0}}, {{42, 10}}},
+      {{{42, 0}}, {{55, 10}}}
     };
 
     for (int i = 0; i < 4; i++)
@@ -85,19 +85,19 @@ TEST(StructPartitioner, Serial) {
 
   {
     // Partition 55x10x12 mesh into 8 partitions
-    std::array<int64_t, 3> ncells = {55, 10, 12};
+    std::array<int64_t, 3> ncells = {{55, 10, 12}};
 
     auto partlimits = Wonton::structured_partitioner<3>(8, ncells);
 
     std::vector<std::vector<std::array<int64_t, 3>>> exp_partlimits = {
-      {{ 0, 0, 0}, {28,  5,  6}},
-      {{ 0, 0, 6}, {28,  5, 12}},
-      {{ 0, 5, 0}, {28, 10,  6}},
-      {{ 0, 5, 6}, {28, 10, 12}},
-      {{28, 0, 0}, {55,  5,  6}},
-      {{28, 0, 6}, {55,  5, 12}},
-      {{28, 5, 0}, {55, 10,  6}},
-      {{28, 5, 6}, {55, 10, 12}}
+      {{{ 0, 0, 0}}, {{28,  5,  6}}},
+      {{{ 0, 0, 6}}, {{28,  5, 12}}},
+      {{{ 0, 5, 0}}, {{28, 10,  6}}},
+      {{{ 0, 5, 6}}, {{28, 10, 12}}},
+      {{{28, 0, 0}}, {{55,  5,  6}}},
+      {{{28, 0, 6}}, {{55,  5, 12}}},
+      {{{28, 5, 0}}, {{55, 10,  6}}},
+      {{{28, 5, 6}}, {{55, 10, 12}}}
     };
 
 
@@ -109,19 +109,19 @@ TEST(StructPartitioner, Serial) {
 
   {
     // Partition 55x10x12 mesh into 8 partitions BUT ONLY IN 2 DIRS
-    std::array<int64_t, 3> ncells = {55, 10, 12};
+    std::array<int64_t, 3> ncells = {{55, 10, 12}};
 
     auto partlimits = Wonton::structured_partitioner<3>(8, ncells, 2);
 
     std::vector<std::vector<std::array<int64_t, 3>>> exp_partlimits = {
-      {{ 0, 0, 0}, {14,  5, 12}},
-      {{ 0, 5, 0}, {14, 10, 12}},
-      {{14, 0, 0}, {28,  5, 12}},
-      {{14, 5, 0}, {28, 10, 12}},
-      {{28, 0, 0}, {42,  5, 12}},
-      {{28, 5, 0}, {42, 10, 12}},
-      {{42, 0, 0}, {55,  5, 12}},
-      {{42, 5, 0}, {55, 10, 12}}
+      {{{ 0, 0, 0}}, {{14,  5, 12}}},
+      {{{ 0, 5, 0}}, {{14, 10, 12}}},
+      {{{14, 0, 0}}, {{28,  5, 12}}},
+      {{{14, 5, 0}}, {{28, 10, 12}}},
+      {{{28, 0, 0}}, {{42,  5, 12}}},
+      {{{28, 5, 0}}, {{42, 10, 12}}},
+      {{{42, 0, 0}}, {{55,  5, 12}}},
+      {{{42, 5, 0}}, {{55, 10, 12}}}
     };
 
 
@@ -133,16 +133,16 @@ TEST(StructPartitioner, Serial) {
 
   {
     // Partition 55x10x5 mesh into 5 partitions BUT ONLY IN 1 DIR
-    std::array<int64_t, 3> ncells = {55, 10, 5};
+    std::array<int64_t, 3> ncells = {{55, 10, 5}};
 
     auto partlimits = Wonton::structured_partitioner<3>(5, ncells, 1);
 
     std::vector<std::vector<std::array<int64_t, 3>>> exp_partlimits = {
-      {{ 0, 0, 0}, {11, 10, 5}},
-      {{11, 0, 0}, {22, 10, 5}},
-      {{22, 0, 0}, {33, 10, 5}},
-      {{33, 0, 0}, {44, 10, 5}},
-      {{44, 0, 0}, {55, 10, 5}}
+      {{{ 0, 0, 0}}, {{11, 10, 5}}},
+      {{{11, 0, 0}}, {{22, 10, 5}}},
+      {{{22, 0, 0}}, {{33, 10, 5}}},
+      {{{33, 0, 0}}, {{44, 10, 5}}},
+      {{{44, 0, 0}}, {{55, 10, 5}}}
     };
 
     for (int i = 0; i < 5; i++)

--- a/wonton/support/test/test_structured_partitioner_par.cc
+++ b/wonton/support/test/test_structured_partitioner_par.cc
@@ -24,7 +24,7 @@ TEST(StructuredPartioner, Parallel) {
       // many partitions we are requesting).
 
       int seed = 42;
-      std::array<int64_t, 3> ncells = {144, 256, 16};
+      std::array<int64_t, 3> ncells = {{144, 256, 16}};
       auto partlimits = Wonton::structured_partitioner<3>(16, ncells, 3, seed);
 
       int64_t limitsarray[96];  // flattened array


### PR DESCRIPTION
Use double curly braces for array initialization 
IBM XL compiler does not like initialization of maps with {}