### PR TITLE
[WIP] add conduit/blueprint mesh wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,40 @@ if (WONTON_ENABLE_Jali AND WONTON_ENABLE_MPI AND NOT Jali_LIBRARIES)
 endif ()
 
 
+#------------------------------------------------------------------------------#
+# Locate Conduit
+#------------------------------------------------------------------------------#
+
+set(WONTON_ENABLE_Conduit False CACHE BOOL "Conduit/Blueprint Interface enabled?")
+
+if (WONTON_ENABLE_Conduit AND NOT Conduit_LIBRARIES)
+  # Look for the Conduit package
+  
+  find_package(Conduit REQUIRED)  # specify in Conduit_ROOT or CMAKE_PREFIX_PATH
+
+  # Similar to Kokkos; Conduit doesn't set 'Conduit_LIBRARIES', so we set it manually
+  set(Conduit_LIBRARIES "conduit::conduit" CACHE STRING "Conduit top level target")
+
+  message(STATUS "Located Conduit")
+  message(STATUS "Conduit_LIBRARIES ${Conduit_LIBRARIES}")
+
+  target_link_libraries(wonton INTERFACE ${Conduit_LIBRARIES})
+  
+  if (NOT Conduit_ROOT)
+    # Conduit_CONFIG should be the full path to where the config file was found
+    # which is typically SOMEDIR/lib/cmake - back out Conduit_ROOT from that
+    # until we fix ConduitConfig
+    get_filename_component(Conduit_CONFIGLOC ${Conduit_CONFIG} DIRECTORY)
+    get_filename_component(Conduit_CONFIGLOC_UP1 ${Conduit_CONFIGLOC} DIRECTORY)
+    get_filename_component(Conduit_CONFIGLOC_UP2 ${Conduit_CONFIGLOC_UP1} DIRECTORY)
+    get_filename_component(Conduit_ROOT ${Conduit_CONFIGLOC_UP2} DIRECTORY CACHE "Where Conduit lives")
+  endif ()
+  message(STATUS "Conduit_ROOT ${Conduit_ROOT}")
+  
+  target_compile_definitions(wonton INTERFACE WONTON_ENABLE_Conduit)
+endif ()
+
+
 #-----------------------------------------------------------------------------
 # Thrust information
 #-----------------------------------------------------------------------------

--- a/wonton/mesh/CMakeLists.txt
+++ b/wonton/mesh/CMakeLists.txt
@@ -34,6 +34,10 @@ if (WONTON_ENABLE_FleCSI)
   add_subdirectory(flecsi)
 endif ()
 
+if (WONTON_ENABLE_Conduit)
+  add_subdirectory(conduit)
+endif ()
+
 add_subdirectory(simple)
 
 add_subdirectory(adaptive_refinement)

--- a/wonton/mesh/conduit/CMakeLists.txt
+++ b/wonton/mesh/conduit/CMakeLists.txt
@@ -1,0 +1,54 @@
+#[[
+This file is part of the Ristra Wonton project.
+Please see the license file at the root of this repository, or at:
+    https://github.com/laristra/wonton/blob/master/LICENSE
+]]
+#-----------------------------------------------------------------------------~#
+
+if (WONTON_ENABLE_Conduit)
+
+  add_library(conduit_mesh_wrapper INTERFACE)
+
+  target_include_directories(conduit_mesh_wrapper INTERFACE
+    $<BUILD_INTERFACE:${wonton_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${wonton_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>)
+
+  set(conduit_mesh_wrapper_HEADERS
+    conduit_mesh_wrapper.h
+    )
+
+  # Not yet allowed for INTERFACE libraries
+  #
+  # set_target_properties(conduit_mesh_wrapper install(DIRECTORY ${wonton_SOURCE_DIR}/include/SI DESTINATION include)PROPERTIES
+  #   PUBLIC_HEADER "${conduit_mesh_wrapper_HEADERS}")
+  #
+  # Directly install files instead
+  install(FILES ${conduit_mesh_wrapper_HEADERS}
+    DESTINATION include/wonton/mesh/conduit)
+  
+  target_link_libraries(conduit_mesh_wrapper INTERFACE wonton_support)
+
+
+  # Conduit dependencies
+  target_link_libraries(conduit_mesh_wrapper INTERFACE ${Conduit_LIBRARIES})
+
+  target_link_libraries(wonton_mesh INTERFACE conduit_mesh_wrapper)
+
+  install(TARGETS conduit_mesh_wrapper
+  EXPORT wonton_LIBRARIES
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  PUBLIC_HEADER DESTINATION include/wonton/mesh/conduit
+  INCLUDES DESTINATION include/wonton/mesh/conduit
+  )
+
+  if (ENABLE_UNIT_TESTS)
+    wonton_add_unittest(test_conduit_mesh_wrapper
+      SOURCES test/test_conduit_mesh_wrapper.cc
+      LIBRARIES conduit_mesh_wrapper
+      POLICY SERIAL)  
+  endif ()
+
+endif()

--- a/wonton/mesh/conduit/conduit_mesh_wrapper.h
+++ b/wonton/mesh/conduit/conduit_mesh_wrapper.h
@@ -1,0 +1,30 @@
+/*
+This file is part of the Ristra Wonton project.
+Please see the license file at the root of this repository, or at:
+    https://github.com/laristra/wonton/blob/master/LICENSE
+*/
+
+#ifndef CONDUIT_MESH_WRAPPER_H_
+#define CONDUIT_MESH_WRAPPER_H_
+
+#include <cassert>
+#include <algorithm>
+#include <vector>
+#include <array>
+#include <utility>
+
+#include "conduit/conduit.hpp"                  // Conduit header
+
+#include "wonton/mesh/AuxMeshTopology.h"
+#include "wonton/support/wonton.h"
+#include "wonton/support/Point.h"
+
+namespace Wonton {
+
+std::string conduit_about() {
+    return conduit::about();
+}
+
+}  // end namespace Wonton
+
+#endif // CONDUIT_MESH_WRAPPER_H_

--- a/wonton/mesh/conduit/test/test_conduit_mesh_wrapper.cc
+++ b/wonton/mesh/conduit/test/test_conduit_mesh_wrapper.cc
@@ -1,0 +1,22 @@
+/*
+This file is part of the Ristra Wonton project.
+Please see the license file at the root of this repository, or at:
+    https://github.com/laristra/wonton/blob/master/LICENSE
+*/
+
+#include "wonton/mesh/conduit/conduit_mesh_wrapper.h"
+
+#include <iostream>
+
+#include "gtest/gtest.h"
+
+#include "wonton/support/Point.h"
+
+/*!
+  file test_conduit_mesh_wrapper.cc
+  @brief Unit tests for the Conduit mesh wrapper class
+ */
+
+TEST(Conduit_Mesh_Wrapper, Sanity_Test) {
+  ASSERT_NE(Wonton::conduit_about(), "");
+}


### PR DESCRIPTION
The changes in this pull request add [Conduit's Blueprint schema](https://llnl-conduit.readthedocs.io/en/latest/blueprint.html) as a supported option for Wonton, which includes all of the following additions:

- [ ] Add Conduit as an optional dependency for Wonton.
- [ ] Add an annotated interface skeleton for the Blueprint Wonton API.
- [ ] Fill in the implementation for the Blueprint Wonton API skeleton.
- [ ] Add one or more nontrivial test cases for the Blueprint Wonton API.